### PR TITLE
[fix]deckオブジェクト削除の際、中間テーブルdeck_tagsも削除するように変更

### DIFF
--- a/app/controllers/decks_controller.rb
+++ b/app/controllers/decks_controller.rb
@@ -69,6 +69,7 @@ class DecksController < ApplicationController
   def destroy_your_deck
     @deck = Deck.find(params[:id])
     @deck.deck_cards.destroy_all
+    @deck.deck_tags.destroy_all
     @deck.destroy!
     redirect_to your_decks_path, success: "デッキを削除しました", status: :see_other
   end


### PR DESCRIPTION
デッキ削除時の挙動のミスを修正 (中間テーブルのレコードを先に削除する)